### PR TITLE
refactor of searcher classes and their unit tests

### DIFF
--- a/src/LibrarySystem.Tests/Unit/Searchers/AuthorSearcherTests.cs
+++ b/src/LibrarySystem.Tests/Unit/Searchers/AuthorSearcherTests.cs
@@ -1,8 +1,10 @@
+using System.ComponentModel.Design;
 using LibrarySystem.Application.Services.Authors;
 using LibrarySystem.Domain.Entities;
 using LibrarySystem.Domain.Interfaces.Common;
 using LibrarySystem.Domain.Interfaces.Repositories;
 using LibrarySystem.Tests.Integration.Factories;
+using Microsoft.IdentityModel.Tokens;
 using Moq;
 
 namespace LibrarySystem.Tests.Unit.Searchers;
@@ -31,16 +33,18 @@ public class AuthorSearcherTests
             authors.Add(AuthorFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random authors from the list
         var authorToSearchFor1 = authors[_random.Next(authors.Count)];
         var authorToSearchFor2 = authors[_random.Next(authors.Count)];
-        authorToSearchFor1.Name = "testing";
-        authorToSearchFor2.Name = "test author";
+        authorToSearchFor1.Name = $"test {keyword}";
+        authorToSearchFor2.Name = $"{keyword} test";
 
         _repository.Setup(r => r.Author.IndexAsync()).ReturnsAsync(authors.OrderBy(a => a.CreatedAt));
 
         // act & assert
-        var searchedAuthors = await _searcher.SearchAsync("test");
+        var searchedAuthors = await _searcher.SearchAsync(keyword);
 
         searchedAuthors.Count().Should().Be(2);
         searchedAuthors.Contains(authorToSearchFor1).Should().BeTrue();
@@ -58,14 +62,16 @@ public class AuthorSearcherTests
             authors.Add(AuthorFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random author from the list
         var authorToSearchFor1 = authors[_random.Next(authors.Count)];
-        authorToSearchFor1.Name = "test not so";
+        authorToSearchFor1.Name = $"test {keyword}";
 
         _repository.Setup(r => r.Author.IndexAsync()).ReturnsAsync(authors.OrderBy(a => a.CreatedAt));
 
         // act & assert
-        var searchedAuthors = await _searcher.SearchAsync("\t test not so          \n ");
+        var searchedAuthors = await _searcher.SearchAsync($"\t {keyword}          \n ");
 
         searchedAuthors.Count().Should().Be(1);
         searchedAuthors.Contains(authorToSearchFor1).Should().BeTrue();
@@ -82,16 +88,18 @@ public class AuthorSearcherTests
             authors.Add(AuthorFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random authors from the list
         var authorToSearchFor1 = authors[_random.Next(authors.Count)];
         var authorToSearchFor2 = authors[_random.Next(authors.Count)];
-        authorToSearchFor1.Name = "test not so";
-        authorToSearchFor2.Name = "not so test";
+        authorToSearchFor1.Name = $"{keyword} test";
+        authorToSearchFor2.Name = $"test {keyword}";
 
         _repository.Setup(r => r.Author.IndexAsync()).ReturnsAsync(authors.OrderBy(a => a.CreatedAt));
 
         // act & assert
-        var searchedAuthors = await _searcher.SearchAsync($"{AuthorSearcher.FILTER_OPERATOR}test");
+        var searchedAuthors = await _searcher.SearchAsync($"{AuthorSearcher.FILTER_OPERATOR}{keyword}");
 
         searchedAuthors.Count().Should().Be(1);
         searchedAuthors.Contains(authorToSearchFor1).Should().BeTrue();
@@ -108,16 +116,18 @@ public class AuthorSearcherTests
             authors.Add(AuthorFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random authors from the list
         var authorToSearchFor1 = authors[_random.Next(authors.Count)];
         var authorToSearchFor2 = authors[_random.Next(authors.Count)];
-        authorToSearchFor1.Name = "not so test";
-        authorToSearchFor2.Name = "test not so";
+        authorToSearchFor1.Name = $"test {keyword}";
+        authorToSearchFor2.Name = $"{keyword} test";
 
         _repository.Setup(r => r.Author.IndexAsync()).ReturnsAsync(authors.OrderBy(a => a.CreatedAt));
 
         // act & assert
-        var searchedAuthors = await _searcher.SearchAsync($"test{AuthorSearcher.FILTER_OPERATOR}");
+        var searchedAuthors = await _searcher.SearchAsync($"{keyword}{AuthorSearcher.FILTER_OPERATOR}");
 
         searchedAuthors.Count().Should().Be(1);
         searchedAuthors.Contains(authorToSearchFor1).Should().BeTrue();

--- a/src/LibrarySystem.Tests/Unit/Searchers/BookSearcherTests.cs
+++ b/src/LibrarySystem.Tests/Unit/Searchers/BookSearcherTests.cs
@@ -3,6 +3,7 @@ using LibrarySystem.Domain.Entities;
 using LibrarySystem.Domain.Interfaces.Common;
 using LibrarySystem.Domain.Interfaces.Repositories;
 using LibrarySystem.Tests.Integration.Factories;
+using Microsoft.IdentityModel.Tokens;
 using Moq;
 
 namespace LibrarySystem.Tests.Unit.Searchers;
@@ -37,16 +38,18 @@ public class BookSearcherTests
             books.Add(BookFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random books from the list
         var bookToSearchFor1 = books[_random.Next(books.Count)];
         var bookToSearchFor2 = books[_random.Next(books.Count)];
-        bookToSearchFor1.Title = "testing";
-        bookToSearchFor2.Description = "test";
+        bookToSearchFor1.Title = $"{keyword} test";
+        bookToSearchFor2.Description = $"test {keyword}";
 
         _repository.Setup(r => r.Book.IndexAsync()).ReturnsAsync(books.OrderBy(b => b.CreatedAt));
 
         // act & assert
-        var searchedBooks = await _searcher.SearchAsync("test");
+        var searchedBooks = await _searcher.SearchAsync(keyword);
 
         searchedBooks.Count().Should().Be(2);
         searchedBooks.Contains(bookToSearchFor1).Should().BeTrue();
@@ -65,16 +68,18 @@ public class BookSearcherTests
             books.Add(BookFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random books from the list
         var bookToSearchFor1 = books[_random.Next(books.Count)];
         var bookToSearchFor2 = books[_random.Next(books.Count)];
-        bookToSearchFor1.Title = "test not so";
-        bookToSearchFor2.Description = "test not so";
+        bookToSearchFor1.Title = $"{keyword} test";
+        bookToSearchFor2.Description = $"test {keyword}";
 
         _repository.Setup(r => r.Book.IndexAsync()).ReturnsAsync(books.OrderBy(b => b.CreatedAt));
 
         // act & assert
-        var searchedBooks = await _searcher.SearchAsync("\t test not so          \n ");
+        var searchedBooks = await _searcher.SearchAsync($"\t  {keyword}         \n ");
 
         searchedBooks.Count().Should().Be(2);
         searchedBooks.Contains(bookToSearchFor1).Should().BeTrue();
@@ -93,16 +98,18 @@ public class BookSearcherTests
             books.Add(BookFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random books from the list
         var bookToSearchFor1 = books[_random.Next(books.Count)];
         var bookToSearchFor2 = books[_random.Next(books.Count)];
-        bookToSearchFor1.Title = "test not so";
-        bookToSearchFor2.Description = "not so test";
+        bookToSearchFor1.Title = $"{keyword} test";
+        bookToSearchFor2.Description = $"test {keyword}";
 
         _repository.Setup(r => r.Book.IndexAsync()).ReturnsAsync(books.OrderBy(b => b.CreatedAt));
 
         // act & assert
-        var searchedBooks = await _searcher.SearchAsync($"{BookSearcher.FILTER_OPERATOR}test");
+        var searchedBooks = await _searcher.SearchAsync($"{BookSearcher.FILTER_OPERATOR}{keyword}");
 
         searchedBooks.Count().Should().Be(1);
         searchedBooks.Contains(bookToSearchFor1).Should().BeTrue();
@@ -120,16 +127,18 @@ public class BookSearcherTests
             books.Add(BookFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random books from the list
         var bookToSearchFor1 = books[_random.Next(books.Count)];
         var bookToSearchFor2 = books[_random.Next(books.Count)];
-        bookToSearchFor1.Title = "test not so";
-        bookToSearchFor2.Description = "not so test";
+        bookToSearchFor1.Title = $"test {keyword}";
+        bookToSearchFor2.Description = $"{keyword} test";
 
         _repository.Setup(r => r.Book.IndexAsync()).ReturnsAsync(books.OrderBy(b => b.CreatedAt));
 
         // act & assert
-        var searchedBooks = await _searcher.SearchAsync($"so{BookSearcher.FILTER_OPERATOR}");
+        var searchedBooks = await _searcher.SearchAsync($"{keyword}{BookSearcher.FILTER_OPERATOR}");
 
         searchedBooks.Count().Should().Be(1);
         searchedBooks.Contains(bookToSearchFor1).Should().BeTrue();
@@ -144,11 +153,11 @@ public class BookSearcherTests
         var genre = GenreFactory.CreateWithFakeData();
         var author = AuthorFactory.CreateWithFakeData();
 
-        var query = "test";
+        var keyword = Guid.NewGuid().ToString();
 
         // change both genre and authors name so we can find by them
-        genre.Name = query;
-        author.Name = query;
+        genre.Name = keyword;
+        author.Name = keyword;
 
         for (int i = 0; i < 100; i++)
         {
@@ -162,14 +171,14 @@ public class BookSearcherTests
         var bookToSearchFor3 = books[_random.Next(books.Count)];
         bookToSearchFor1.Genres = [genre];
         bookToSearchFor2.Authors = [author];
-        bookToSearchFor3.Title = query;
+        bookToSearchFor3.Title = keyword;
 
         _repository.Setup(r => r.Book.IndexAsync()).ReturnsAsync(books.OrderBy(b => b.CreatedAt));
-        _genreSearcher.Setup(gs => gs.SearchAsync(query)).ReturnsAsync([genre]);
-        _authorSearcher.Setup(gs => gs.SearchAsync(query)).ReturnsAsync([author]);
+        _genreSearcher.Setup(gs => gs.SearchAsync(keyword)).ReturnsAsync([genre]);
+        _authorSearcher.Setup(gs => gs.SearchAsync(keyword)).ReturnsAsync([author]);
 
         // act & assert
-        var searchedBooks = await _searcher.SearchAsync(query);
+        var searchedBooks = await _searcher.SearchAsync(keyword);
 
         searchedBooks.Count().Should().Be(3);
         searchedBooks.Contains(bookToSearchFor1).Should().BeTrue();

--- a/src/LibrarySystem.Tests/Unit/Searchers/GenreSearcherTests.cs
+++ b/src/LibrarySystem.Tests/Unit/Searchers/GenreSearcherTests.cs
@@ -3,6 +3,7 @@ using LibrarySystem.Domain.Entities;
 using LibrarySystem.Domain.Interfaces.Common;
 using LibrarySystem.Domain.Interfaces.Repositories;
 using LibrarySystem.Tests.Integration.Factories;
+using Microsoft.IdentityModel.Tokens;
 using Moq;
 
 namespace LibrarySystem.Tests.Unit.Searchers;
@@ -31,14 +32,16 @@ public class GenreSearcherTests
             genres.Add(GenreFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random genre from the list
         var genreToSearchFor = genres[_random.Next(genres.Count)];
-        genreToSearchFor.Name = "test";
+        genreToSearchFor.Name = $"test {keyword}";
 
         _repository.Setup(r => r.Genre.IndexAsync()).ReturnsAsync(genres);
 
         // act & assert
-        var searchedGenres = await _searcher.SearchAsync("tes");
+        var searchedGenres = await _searcher.SearchAsync(keyword);
 
         searchedGenres.Count().Should().Be(1);
         searchedGenres.Contains(genreToSearchFor).Should().BeTrue();
@@ -55,14 +58,16 @@ public class GenreSearcherTests
             genres.Add(GenreFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random genre from the list
         var genreToSearchFor = genres[_random.Next(genres.Count)];
-        genreToSearchFor.Name = "test";
+        genreToSearchFor.Name = $"test {keyword}";
 
         _repository.Setup(r => r.Genre.IndexAsync()).ReturnsAsync(genres.OrderBy(g => g.CreatedAt));
 
         // act & assert
-        var searchedGenres = await _searcher.SearchAsync("\t test          \n ");
+        var searchedGenres = await _searcher.SearchAsync($"\t {keyword}          \n ");
 
         searchedGenres.Count().Should().Be(1);
         searchedGenres.Contains(genreToSearchFor).Should().BeTrue();
@@ -79,16 +84,18 @@ public class GenreSearcherTests
             genres.Add(GenreFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random genres from the list
         var genreToSearchFor1 = genres[_random.Next(genres.Count)];
         var genreToSearchFor2 = genres[_random.Next(genres.Count)];
-        genreToSearchFor1.Name = "test not so";
-        genreToSearchFor2.Name = "so not test";
+        genreToSearchFor1.Name = $"{keyword} test";
+        genreToSearchFor2.Name = $"test {keyword}";
 
         _repository.Setup(r => r.Genre.IndexAsync()).ReturnsAsync(genres.OrderBy(g => g.CreatedAt));
 
         // act & assert
-        var searchedGenres = await _searcher.SearchAsync($"{GenreSearcher.FILTER_OPERATOR}test");
+        var searchedGenres = await _searcher.SearchAsync($"{GenreSearcher.FILTER_OPERATOR}{keyword}");
 
         searchedGenres.Count().Should().Be(1);
         searchedGenres.Contains(genreToSearchFor1).Should().BeTrue();
@@ -105,18 +112,20 @@ public class GenreSearcherTests
             genres.Add(GenreFactory.CreateWithFakeData());
         }
 
+        var keyword = Guid.NewGuid().ToString();
+
         // get random genres from the list
         var genreToSearchFor1 = genres[_random.Next(genres.Count)];
         var genreToSearchFor2 = genres[_random.Next(genres.Count)];
-        genreToSearchFor1.Name = "test not so";
-        genreToSearchFor2.Name = "so not test";
+        genreToSearchFor1.Name = $"test {keyword}";
+        genreToSearchFor2.Name = $"{keyword} test";
 
         _repository.Setup(r => r.Genre.IndexAsync()).ReturnsAsync(genres.OrderBy(g => g.CreatedAt));
 
         // act & assert
-        var searchedGenres = await _searcher.SearchAsync($"test{GenreSearcher.FILTER_OPERATOR}");
+        var searchedGenres = await _searcher.SearchAsync($"{keyword}{GenreSearcher.FILTER_OPERATOR}");
 
         searchedGenres.Count().Should().Be(1);
-        searchedGenres.Contains(genreToSearchFor2).Should().BeTrue();
+        searchedGenres.Contains(genreToSearchFor1).Should().BeTrue();
     }
 }


### PR DESCRIPTION
Refactor of searcher classes and their unit tests

- Refactored GenreSearcherTests, AuthorSearcherTests, BookSearcherTests classes
  - Used general random keywords instead of a hardcoded values
- Changes in BookSearcher class
  - Fixed when searching with 'ends with' filter a method StartsWith was used instead of EndsWith resulting in incorrect filtering
  - Added comments to explain more complex LINQ expressions, also renamed few variables